### PR TITLE
Fix tests

### DIFF
--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -111,8 +111,8 @@ def extract(
                 raise RuntimeError(
                     f"No extractors found for file type {input_type!r} in the registry"
                 )
-            elif len(extractors) > 1:
-                print(f"Discovered multiple extractors: {extractors}.")
+            elif len(extractors) > 0:
+                print(f"Discovered the following extractors: {extractors}.")
 
             for extractor in extractors:
                 try:
@@ -133,6 +133,7 @@ def extract(
                         print(f"Found matching usage with extractor: {extractor!r}")
                         break
                 else:
+                    # We reset entry_json here since we didn't find matching usage.
                     entry_json = None
             if entry_json is None:
                 raise RuntimeError(

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -112,19 +112,32 @@ def extract(
                     f"No extractors found for file type {input_type!r} in the registry"
                 )
             elif len(extractors) > 1:
-                print(
-                    f"Discovered multiple extractors: {extractors}, using the first ({extractors[0]})"
-                )
+                print(f"Discovered multiple extractors: {extractors}.")
 
-            extractor = extractors[0]
-            try:
-                request_url = f"{registry_base_url}/extractors/{extractor}"
-                entry = urllib.request.urlopen(request_url)
-            except urllib.error.HTTPError as e:
+            for extractor in extractors:
+                try:
+                    request_url = f"{registry_base_url}/extractors/{extractor}"
+                    entry = urllib.request.urlopen(request_url)
+                except urllib.error.HTTPError as e:
+                    raise RuntimeError(
+                        f"Could not find extractor {extractor!r} in the registry at {request_url!r}.\nFull error: {e}"
+                    )
+                entry_json = json.loads(entry.read().decode("utf-8"))["data"]
+                for usage in entry_json["usage"]:
+                    if preferred_mode != SupportedExecutionMethod(usage["method"]):
+                        continue
+                    if (
+                        input_type in usage["supported_filetypes"]
+                        or usage["supported_filetypes"] == []
+                    ):
+                        print(f"Found matching usage with extractor: {extractor!r}")
+                        break
+                else:
+                    entry_json = None
+            if entry_json is None:
                 raise RuntimeError(
-                    f"Could not find extractor {extractor!r} in the registry at {request_url!r}.\nFull error: {e}"
+                    "No extractors found with the preferred execution mode and input type."
                 )
-            entry_json = json.loads(entry.read().decode("utf-8"))["data"]
 
             plan = ExtractorPlan(
                 entry_json,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ docs = [
 
 formats = [
     "pandas",
-    "xarray"
+    "xarray",
+    "xarray-datatree",
 ]
 
 dev = [


### PR DESCRIPTION
Since we now have `galvani` and `yadg` in `yard`, the tests were actually installing `galvani` for most cases. Fix tests by:

- adding `xarray-datatree` to `[formats]`, since it's needed by `yadg>=5.1` (this is temporary and won't be needed once `Datatree` is in parent `xarray`
- add more logic to `extract()` so that `preferred_mode` is matched

This means for `cli` tests the `mpr` test suite runs with `yadg` and for `python` tests it runs with `galvani`.