### PR TITLE
Add `beam` command line interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ ret = extract("example.mpr", "biologic-mpr", output_path="output.nc", preferred_
 
 In this case, the `ret` will be empty bytes, and the output of the extractor should appear in the `output.nc` file.
 
+Finally, `beam` can also be executed from the command line, implying `preferred_mode="cli"`. The command line invocation equivalent to the above python syntax is:
+
+```bash
+beam biologic-mpr example.mpr --outfile output.nc
+```
+
 
 ### Plans
 
@@ -77,7 +83,7 @@ In this case, the `ret` will be empty bytes, and the output of the extractor sho
       across subprocesses without any extractor specific classes,
       e.g., raw JSON/Python dicts, pandas dataframes or xarray datasets (as
       optional requirements, by demand).
-- [ ] A command-line for quickly running e.g., `beam <filename>`
+- [x] A command-line for quickly running e.g., `beam <filename>`
 - [ ] Extractor scaffold/template/plugin
     - If it can be kept similarly low-dependency, this package could also
       implement an extractor scaffold for those who want to modify existing

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ret = extract("example.mpr", "biologic-mpr", output_path="output.nc", preferred_
 
 In this case, the `ret` will be empty bytes, and the output of the extractor should appear in the `output.nc` file.
 
-Finally, `beam` can also be executed from the command line, implying `preferred_mode="cli"`. The command line invocation equivalent to the above python syntax is:
+Finally, `beam` can also be executed from the command line, implying `preferred_mode="cli"`. The command line invocation equivalent to the above Python syntax is:
 
 ```bash
 beam biologic-mpr example.mpr --outfile output.nc

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Repository containing the reference implementation of the Datatractor API, published at [![Datatractor Yard](https://badgen.net/static/%F0%9F%9A%9Cdatatractor/yard)](https://yard.datatractor.org/).
 
-## `datatractor_beam` package
+## `datatractor-beam` package
 
 This repository contains a draft Python 3.10 package, located under the `./beam` directory.
 The package can be used to:

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -13,7 +13,7 @@ API endpoints exposed on the |yardsite|_. Currently, it can be used to:
 .. _yardsite: https://yard.datatractor.org/
 
 """
-
+import argparse
 import json
 import multiprocessing.managers
 import multiprocessing.shared_memory
@@ -24,12 +24,11 @@ import subprocess
 import urllib.error
 import urllib.request
 import venv
-import argparse
 from enum import Enum
+from importlib import metadata
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Optional
-from importlib import metadata
 
 __all__ = ("extract", "Extractor")
 
@@ -68,11 +67,19 @@ def run_beam():
         default=None,
     )
 
+    argparser.add_argument(
+        "--outfile",
+        "-o",
+        help="Optional path of the output file",
+        default=None,
+    )
+
     args = argparser.parse_args()
 
     extract(
         input_path=args.infile,
         input_type=args.filetype,
+        output_path=args.outfile,
         preferred_mode=SupportedExecutionMethod.CLI,
     )
 

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -15,6 +15,7 @@ API endpoints exposed on the |yardsite|_. Currently, it can be used to:
 """
 
 import argparse
+import importlib.metadata
 import json
 import multiprocessing.managers
 import multiprocessing.shared_memory
@@ -26,12 +27,12 @@ import urllib.error
 import urllib.request
 import venv
 from enum import Enum
-from importlib import metadata
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Optional
 
 __all__ = ("extract", "Extractor")
+__version__ = importlib.metadata.version("datatractor-beam")
 
 REGISTRY_BASE_URL = "https://yard.datatractor.org/api/v0.1.0"
 BIN = "Scripts" if platform.system() == "Windows" else "bin"
@@ -49,11 +50,15 @@ class SupportedInstallationMethod(Enum):
 
 
 def run_beam():
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(
+        prog="beam",
+        description="""CLI for datatractor extractors that takes a filename and a filetype, then installs and runs an appropriate extractor, if available, from the chosen registry (default: https://registry.datatractor.org/). Filetype IDs can be found in the registry API at e.g., https://registry.datatractor.org/api/filetypes. If a matching extractor is found at https://registry.datatractor.org/api/extractors, it will be installed into a virtual environment local to the beam installation. The results of the extractor will be written out to a file at --outfile, or in the default location for that output file type.""",
+    )
+
     argparser.add_argument(
         "--version",
         action="version",
-        version=f'%(prog)s version {metadata.version("datatractor_beam")}',
+        version=f"%(prog)s version {__version__}",
     )
 
     argparser.add_argument(
@@ -307,8 +312,6 @@ class ExtractorPlan:
         if output_path is None:
             suffix = ".out" if output_type is None else f".{output_type}"
             output_path = input_path.with_suffix(suffix)
-
-        print(f"{output_type=}")
 
         command = self.apply_template_args(
             command,

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -13,6 +13,7 @@ API endpoints exposed on the |yardsite|_. Currently, it can be used to:
 .. _yardsite: https://yard.datatractor.org/
 
 """
+
 import argparse
 import json
 import multiprocessing.managers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dev = [
 [project.urls]
 repository = "https://github.com/datatractor/beam"
 
+[project.scripts]
+beam = "beam:run_beam"
+
 [tool.ruff]
 extend-exclude = [
     "providers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dynamic = ["version"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",

--- a/tests/test_mpr.py
+++ b/tests/test_mpr.py
@@ -1,3 +1,4 @@
+import subprocess
 import urllib.request
 from pathlib import Path
 
@@ -146,3 +147,13 @@ def test_extractorplan_python_method():
         function, args, kwargs = ExtractorPlan._prepare_python(
             'extract(filename="example.txt", type={"test": "example", "dictionary": "example"})'
         )
+
+
+def test_biologic_beam(tmp_path, test_mprs):
+    for ind, test_mpr in enumerate(test_mprs):
+        input_path = tmp_path / test_mpr
+        output_path = tmp_path / test_mpr.name.replace(".mpr", ".nc")
+        task = ["beam", "biologic-mpr", str(input_path), "--outfile", str(output_path)]
+        subprocess.run(task)
+        assert output_path.exists()
+        break


### PR DESCRIPTION
Depends on #3.

Adds `beam` CLI with the following interface:

```
(beam) PS C:\Users\Kraus\Code\datatractor\beam> beam
usage: beam [-h] [--version] [--outfile OUTFILE] filetype infile
beam: error: the following arguments are required: filetype, infile
```

```
usage: beam [-h] [--version] [--outfile OUTFILE] filetype infile

positional arguments:
  filetype              FileType.ID of the input file
  infile                Path of the input file

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --outfile OUTFILE, -o OUTFILE
                        Optional path of the output file
```