### PR TITLE
Use unversioned yard API URL

### DIFF
--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Optional
 __all__ = ("extract", "Extractor")
 __version__ = importlib.metadata.version("datatractor-beam")
 
-REGISTRY_BASE_URL = "https://yard.datatractor.org/api/v0.1.0"
+REGISTRY_BASE_URL = "https://yard.datatractor.org/api/"
 BIN = "Scripts" if platform.system() == "Windows" else "bin"
 
 


### PR DESCRIPTION
Since 0.1.1 was released, the former URL fails. We should use the unversioned URL for now and consider constraining again to minor/major version in the future.