### PR TITLE
A new `datatractor` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ pip install .
 
 ### Usage
 
-Currently, you can use the `extract` function from the `beam` module inside your own Python code:
+#### As a Python module
+To extract data from a file, you can use the `extract` function from the `beam` module inside your own Python code:
 
 ```python
-from beam import extract
+from datatractor_beam import extract
 
 # extract(<input_type>, <input_path>)
 data = extract("./example.mpr",  "biologic-mpr")
 ```
 
-This example will install the first compatible `biologic-mpr` extractor it finds in the registry into a fresh virtualenv (under `./beam-venvs`), and then execute it on the file at `example.mpr`.
+This example will install the first extractor that is compatible with the `biologic-mpr` filetype that it finds in the registry. It will be installed into a fresh virtualenv (under `./beam-venvs`), and then executed on the file at `example.mpr`.
 
 By default, the `extract` function will attempt to use the extractor's Python-based invocation (i.e. the optional `preferred_mode="python"` argument is specified). This means the extractor will be executed from within python, and the returned `data` object will be a Python object as defined (and supported) by the extractor. This may require additional packages to be installed, for examples `pandas` or `xarray`, which are both supported via the installation command `pip install .[formats]` above. If you encounter the following traceback, a missing "format" (such as `xarray` here) is the likely reason:
 
@@ -63,16 +64,25 @@ ModuleNotFoundError: No module named 'xarray'
 Alternatively, if the `preferred_mode="cli"` argument is specified, the extractor will be executed using its command-line invocation. This means the output of the extractor will most likely be a file, which can be further specified using the `output_type` argument:
 
 ```python
-from beam import extract
+from datatractor_beam import extract
 ret = extract("example.mpr", "biologic-mpr", output_path="output.nc", preferred_mode = "cli")
 ```
 
 In this case, the `ret` will be empty bytes, and the output of the extractor should appear in the `output.nc` file.
 
-Finally, `beam` can also be executed from the command line, implying `preferred_mode="cli"`. The command line invocation equivalent to the above Python syntax is:
+#### As a command line utility
+
+The `datatractor` utility supports the following subcommands:
+
+- `beam`: used to extract data from an input file of a known file type,
+- `probe`: used to search the registry for extractors that match a known file type,
+- `yard`: used to fetch the definition of an extractor from the registry, and
+- `install`: used to install an extractor.
+
+In particular, the `extract()` functionality discussed above can also be executed from the command line, implying `preferred_mode="cli"`. The command line invocation equivalent to the above Python syntax is:
 
 ```bash
-beam biologic-mpr example.mpr --outfile output.nc
+datatractor beam biologic-mpr example.mpr --output-path output.nc
 ```
 
 

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -118,13 +118,13 @@ def run_datatractor():
     )
 
     beam.add_argument(
-        "--output_path",
+        "--output-path",
         "-o",
         help="Optional path of the output file",
         default=None,
     )
     beam.add_argument(
-        "--preferred_mode",
+        "--preferred-mode",
         help="Preferred extraction mode to use with the Extractor (default: cli).",
         default="cli",
         choices=["cli", "python"],

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -214,6 +214,10 @@ def run_datatractor():
     try:
         ret = func(**vars(args))
         if ret is not None and len(ret) > 0:
+            try:
+                ret = json.dumps(ret)
+            except json.JSONDecodeError:
+                pass
             print(ret)
     except RuntimeError as e:
         print(e)
@@ -252,7 +256,7 @@ def search_filetype(
         extractors = fetch_registered_extractors(
             input_type=input_type,
             registry_base_url=registry_base_url,
-        )
+        ).get("registered_extractors", [])
 
     matching_definition = None
     for extractor in extractors:
@@ -490,7 +494,7 @@ def find_matching_usage(
 def fetch_registered_extractors(
     input_type: str,
     registry_base_url: str = REGISTRY_BASE_URL,
-) -> list[dict]:
+) -> dict:
     try:
         request_url = f"{registry_base_url}/filetypes/{input_type}"
         response = urllib.request.urlopen(request_url)
@@ -507,7 +511,7 @@ def fetch_registered_extractors(
         )
     elif len(extractors) > 0:
         logger.info("Discovered the following extractors: %s.", extractors)
-    return extractors
+    return {"id": input_type, "registered_extractors": extractors}
 
 
 class ExtractorPlan:

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -136,8 +136,7 @@ def run_datatractor():
         help="Searches the registry for Extractors available for <input_type>.",
         description=f"""
             Searches the chosen registry (default: {REGISTRY_BASE_URL}) for Extractors
-            matching the provided input_type and returns the full definition of that
-            Extractor.
+            matching the provided input_type and returns their ID(s).
         """,
     )
 
@@ -267,13 +266,17 @@ def search_filetype(
                 )
             extractor = json.loads(entry.read().decode("utf-8"))["data"]
 
-        match = find_matching_usage(
-            usages=extractor["usage"],
-            input_type=input_type,
-            preferred_mode=preferred_mode,
-            preferred_scope=preferred_scope,
-            strict=True,
-        )
+        try:
+            match = find_matching_usage(
+                usages=extractor["usage"],
+                input_type=input_type,
+                preferred_mode=preferred_mode,
+                preferred_scope=preferred_scope,
+                strict=True,
+            )
+        except RuntimeError:
+            match = None
+
         if match is not None:
             logger.info(f"Found matching usage with extractor: {extractor['id']!r}")
             matching_definition = extractor

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -84,7 +84,7 @@ def coerce_preferred(func):
 def run_datatractor():
     parser = argparse.ArgumentParser(
         prog="datatractor",
-        description="CLI for the reference implementation of the Datatractor project.",  # extractors. that takes a filename and a filetype, then installs and runs an appropriate extractor, if available, from the chosen registry (default: https://registry.datatractor.org/). Filetype IDs can be found in the registry API at e.g., https://registry.datatractor.org/api/filetypes. If a matching extractor is found at https://registry.datatractor.org/api/extractors, it will be installed into a virtual environment local to the beam installation. The results of the extractor will be written out to a file at --outfile, or in the default location for that output file type.""",
+        description="CLI for the reference implementation of the Datatractor project.",
     )
 
     parser.add_argument(
@@ -122,6 +122,12 @@ def run_datatractor():
         "-o",
         help="Optional path of the output file",
         default=None,
+    )
+    beam.add_argument(
+        "--preferred_mode",
+        help="Preferred extraction mode to use with the Extractor (default: cli).",
+        default="cli",
+        choices=["cli", "python"],
     )
     beam.set_defaults(func=extract)
 
@@ -197,7 +203,6 @@ def run_datatractor():
         )
 
     args = parser.parse_args()
-    print(args)
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
@@ -347,7 +352,6 @@ def extract(
         The output of the extractor, either a Python object or nothing.
 
     """
-
     tmp_path: Optional[Path] = None
     try:
         if isinstance(input_path, str) and re.match("^http[s]://*", input_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
 repository = "https://github.com/datatractor/beam"
 
 [project.scripts]
-beam = "beam:run_beam"
+datatractor = "beam:run_datatractor"
 
 [tool.ruff]
 extend-exclude = [

--- a/tests/test_mpr.py
+++ b/tests/test_mpr.py
@@ -163,7 +163,14 @@ def test_biologic_beam(tmp_path, test_mprs):
     for ind, test_mpr in enumerate(test_mprs):
         input_path = tmp_path / test_mpr
         output_path = tmp_path / test_mpr.name.replace(".mpr", ".nc")
-        task = ["beam", "biologic-mpr", str(input_path), "--outfile", str(output_path)]
+        task = [
+            "datatractor",
+            "beam",
+            "biologic-mpr",
+            str(input_path),
+            "--output_path",
+            str(output_path),
+        ]
         subprocess.run(task)
         assert output_path.exists()
         break

--- a/tests/test_mpr.py
+++ b/tests/test_mpr.py
@@ -168,7 +168,7 @@ def test_biologic_beam(tmp_path, test_mprs):
             "beam",
             "biologic-mpr",
             str(input_path),
-            "--output_path",
+            "--output-path",
             str(output_path),
         ]
         subprocess.run(task)

--- a/tests/test_mpr.py
+++ b/tests/test_mpr.py
@@ -78,7 +78,14 @@ def test_biologic_extract_no_registry(test_mprs):
             install=(ind == 0),
             extractor_definition={
                 "id": "yadg",
-                "supported_filetypes": [{"id": "biologic-mpr"}],
+                "supported_filetypes": [
+                    {
+                        "id": "biologic-mpr",
+                        "template": {
+                            "input_type": "eclab.mpr",
+                        },
+                    }
+                ],
                 "usage": [
                     {
                         "method": "python",
@@ -93,7 +100,7 @@ def test_biologic_extract_no_registry(test_mprs):
                         "method": "pip",
                         "requires_python": ">=3.9",
                         "requirements": None,
-                        "packages": ["yadg~=5.0"],
+                        "packages": ["yadg~=6.0"],
                     }
                 ],
             },


### PR DESCRIPTION
Addresses #10 by implementing

- `datatractor beam input_type input_path` - install & extract from file
- `datatractor probe input_type` - return registered Extractors for that `input_type`
- `datatractor yard extractor_id` - return extractor definition from registry
- `datatractor install extractor_id` - install Extractor (optionally into venv)