### PR TITLE
Fix usage matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         strategy:
-            max-parallel: 3
+            max-parallel: 4
             matrix:
-                python-version: ['3.10', '3.11', '3.12']
+                python-version: ['3.10', '3.11', '3.12', '3.13']
 
         steps:
 
@@ -46,6 +46,8 @@ jobs:
 
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
+              with:
+                python-version: ${{ matrix.python-version }}
 
             - name: Install dependencies
               run: |

--- a/beam/__init__.py
+++ b/beam/__init__.py
@@ -181,13 +181,16 @@ def extract(
                     )
                 extractor = json.loads(entry.read().decode("utf-8"))["data"]
 
-            match = find_matching_usage(
-                usages=extractor["usage"],
-                input_type=input_type,
-                preferred_mode=preferred_mode,
-                preferred_scope=preferred_scope,
-                strict=True,
-            )
+            try:
+                match = find_matching_usage(
+                    usages=extractor["usage"],
+                    input_type=input_type,
+                    preferred_mode=preferred_mode,
+                    preferred_scope=preferred_scope,
+                    strict=True,
+                )
+            except RuntimeError:
+                match = None
             if match is not None:
                 print(f"Found matching usage with extractor: {extractor['id']!r}")
                 matching_definition = extractor
@@ -575,7 +578,12 @@ class ExtractorPlan:
         preferred_mode: SupportedExecutionMethod = SupportedExecutionMethod.PYTHON,
         preferred_scope: SupportedUsageScope = SupportedUsageScope.DATA,
     ) -> tuple[SupportedExecutionMethod, str, str]:
-        usage = find_matching_usage(usages, input_type, preferred_mode, preferred_scope)
+        try:
+            usage = find_matching_usage(
+                usages, input_type, preferred_mode, preferred_scope
+            )
+        except RuntimeError:
+            usage = None
         if not usage:
             raise RuntimeError(
                 f"No matching usage found for {input_type} with {preferred_mode} and {preferred_scope}"

--- a/tests/test_mpr.py
+++ b/tests/test_mpr.py
@@ -63,7 +63,7 @@ def test_biologic_extract_from_url(tmp_path, test_mpr_urls):
             preferred_mode="python",
             install=(ind == 0),
         )
-        assert data
+        assert data is not None
 
 
 def test_biologic_extract_no_registry(test_mprs):


### PR DESCRIPTION
At some point usage matching was refactored to expect `None` rather than throwing (or vice versa) causing matches to fail if the first candidate failed. This PR fixes that (and probably highlights the need for CLI tests, which would have caught this, since the first match for biologic-mpr fails for CLI atm).